### PR TITLE
Introduce debug flag for console.log and check token is set

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,6 +21,11 @@ class Verifier {
   constructor(params, claims = {}) {
     if (!params.userPoolId) throw Error('userPoolId param is required');
     if (!params.region) throw Error('region param is required');
+    if (!params.debug) {
+      this.debug = true;
+    } else {
+      this.debug = params.debug
+    }
 
     this.userPoolId = params.userPoolId;
     this.region = params.region;
@@ -31,6 +36,8 @@ class Verifier {
 
   async verify(token) {
     try {
+      if (!token) throw Error('token undefined');
+
       const sections = token.split('.');
       const header = JSON.parse(jose.util.base64url.decode(sections[0]));
       const kid = header.kid;
@@ -52,7 +59,7 @@ class Verifier {
       const now = Math.floor(new Date() / 1000);
       if (now > claims.exp) throw Error('Token is expired');
 
-      if (this.expectedClaims.aud && claims.token_use === 'access') console.warn('WARNING! Access tokens do not have an aud claim');
+      if (this.expectedClaims.aud && claims.token_use === 'access' && this.debug) console.warn('WARNING! Access tokens do not have an aud claim');
 
       for (let claim in this.expectedClaims) {
 
@@ -79,7 +86,7 @@ class Verifier {
       }
       return true;
     } catch (e) {
-      console.log(e);
+      if (this.debug) console.log(e);
       return false;
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "verify-cognito-token",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Verify JWT Tokens from AWS Cognito",
   "main": "index.js",
   "scripts": {
@@ -15,5 +15,8 @@
   "dependencies": {
     "node-fetch": "^2.1.2",
     "node-jose": "^2.0.0"
+  },
+  "devDependencies": {
+    "eslint": "^7.17.0"
   }
 }


### PR DESCRIPTION
This introduces a debug flag to optionally suppress console output. Backwards compatibility is given by enabling it by default. Another change is a check whether the token is actually set before processing it further.
